### PR TITLE
Fix fading

### DIFF
--- a/Core/MusicPlayer.cs
+++ b/Core/MusicPlayer.cs
@@ -149,7 +149,8 @@ namespace EnsoMusicPlayer
         /// <param name="timesToLoop">The number of times to loop the track. Set to 0 for endless play.</param>
         public void PlayAtPoint(MusicTrack track, float time, int timesToLoop = 0)
         {
-            CurrentSpeaker.SetVolume(Volume);
+            ResetSpeakerVolumeStatuses();
+            RefreshSpeakerVolume();
             CurrentSpeaker.PlayAtPoint(track, time, timesToLoop);
         }
 
@@ -178,6 +179,15 @@ namespace EnsoMusicPlayer
         }
 
         /// <summary>
+        /// Fades a track gradually toward the given volume level.
+        /// </summary>
+        /// <param name="volume">The level to fade the track to (from 0 to 1)</param>
+        public void FadeTo(float volume)
+        {
+            CurrentSpeaker.FadeTo(volume, CrossFadeTime);
+        }
+
+        /// <summary>
         /// Crossfades to the track with the given name at the given point on its timeline.
         /// </summary>
         /// <param name="name">The name of the track</param>
@@ -198,7 +208,7 @@ namespace EnsoMusicPlayer
         {
             CrossFadeTo(track, timesToLoop);
             Scrub(time);
-            CurrentSpeaker.FadeIn(CrossFadeTime);
+            CurrentSpeaker.FadeInTo(Volume, CrossFadeTime);
         }
 
         /// <summary>
@@ -220,8 +230,9 @@ namespace EnsoMusicPlayer
             CurrentSpeaker.FadeOut(CrossFadeTime, true);
             SwitchSpeakers();
             PlayingTrack = track;
+            CurrentSpeaker.SetSpeakerVolume(0f);
             CurrentSpeaker.Play(PlayingTrack, timesToLoop);
-            CurrentSpeaker.FadeIn(CrossFadeTime);
+            CurrentSpeaker.FadeInTo(Volume, CrossFadeTime);
         }
 
         /// <summary>
@@ -420,8 +431,17 @@ namespace EnsoMusicPlayer
         /// </summary>
         private void RefreshSpeakerVolume()
         {
-            PrimarySpeaker.SetVolume(Volume);
-            SecondarySpeaker.SetVolume(Volume);
+            PrimarySpeaker.SetSpeakerVolume(Volume);
+            SecondarySpeaker.SetSpeakerVolume(Volume);
+        }
+
+        /// <summary>
+        /// Tells the speakers to stop fading if they currently are.
+        /// </summary>
+        private void ResetSpeakerVolumeStatuses()
+        {
+            PrimarySpeaker.StopFading();
+            SecondarySpeaker.StopFading();
         }
     }
 }

--- a/Core/MusicPlayer.cs
+++ b/Core/MusicPlayer.cs
@@ -11,8 +11,6 @@ namespace EnsoMusicPlayer
         [Header("Volume Settings")]
         [Range(0f, 1f)]
         public float Volume = 1f; // Should be considered readonly outside the player's scope.
-        // Remove this as soon as Unity supports C# 6; then we can simply use an auto-field initializer.
-        private float PreviousVolume;
         public float CrossFadeTime = 2f;
 
         [Header("TrackSettings")]
@@ -29,12 +27,9 @@ namespace EnsoMusicPlayer
         {
             PrimarySpeaker = gameObject.AddComponent<Speaker>();
             SecondarySpeaker = gameObject.AddComponent<Speaker>();
-            PrimarySpeaker.Player = this;
-            SecondarySpeaker.Player = this;
+            PrimarySpeaker.SetPlayerAndInitializeVolume(this);
+            SecondarySpeaker.SetPlayerAndInitializeVolume(this);
             CurrentSpeaker = PrimarySpeaker;
-
-            PrimarySpeaker.SetPlayerVolume(Volume);
-            SecondarySpeaker.SetPlayerVolume(Volume);
 
             // Cache all the clips before we play them for maximum performance when starting playback.
             if (Tracks != null)
@@ -44,19 +39,11 @@ namespace EnsoMusicPlayer
                     track.CreateAndCacheClips();
                 }
             }
-
-            RefreshSpeakerVolume(); // Initialize both modules' volume.
         }
 
         // Update is called once per frame
         void Update()
         {
-            // We need this because this is C# 4, not 6...
-            if (Volume != PreviousVolume)
-            {
-                RefreshSpeakerVolume();
-                PreviousVolume = Volume;
-            }
         }
 
         #region PublicAPI
@@ -278,8 +265,7 @@ namespace EnsoMusicPlayer
             if (!PrimarySpeaker.IsFading && !SecondarySpeaker.IsFading)
             {
                 Volume = volume;
-                PrimarySpeaker.SetPlayerVolume(volume);
-                SecondarySpeaker.SetPlayerVolume(volume);
+                RefreshSpeakerVolume();
             }
         }
 

--- a/Core/Speaker.cs
+++ b/Core/Speaker.cs
@@ -28,9 +28,6 @@ namespace EnsoMusicPlayer
         }
 
         public MusicPlayer Player;
-        // Holds the volume of the music player. This is held separately instead of referenced directly
-        // in order to decouple the module from the player.
-        public float PlayerVolume { get; private set; }
 
         public enum VolumeStatuses { FadingIn, FadingOut, Static }
         public VolumeStatuses VolumeStatus { get; private set; }
@@ -94,7 +91,11 @@ namespace EnsoMusicPlayer
             LoopSource = gameObject.AddComponent<AudioSource>();
 
             LoopSource.loop = true;
+        }
 
+        public void SetPlayerAndInitializeVolume(MusicPlayer player)
+        {
+            Player = player;
             InitializeVolume();
         }
 
@@ -119,7 +120,7 @@ namespace EnsoMusicPlayer
                     else
                     {
                         float t = FadeTimeLeft / MaxFadeTime;
-                        SetVolume(PlayerVolume * EnsoHelpers.CalculateEqualPowerCrossfade(t, true));
+                        SetVolume(Player.Volume + (1 - Player.Volume) * EnsoHelpers.CalculateEqualPowerCrossfade(t, true));
                     }
                     break;
 
@@ -131,7 +132,7 @@ namespace EnsoMusicPlayer
                     else
                     {
                         float t = FadeTimeLeft / MaxFadeTime;
-                        SetVolume(PlayerVolume * EnsoHelpers.CalculateEqualPowerCrossfade(t, false));
+                        SetVolume(Player.Volume * EnsoHelpers.CalculateEqualPowerCrossfade(t, false));
                     }
                     break;
             }
@@ -140,15 +141,15 @@ namespace EnsoMusicPlayer
         #region Event Callback
         private void OnFadeInComplete()
         {
-            SetVolume(PlayerVolume);
             VolumeStatus = VolumeStatuses.Static;
+            Player.SetVolume(1);
             Player.OnFadeInComplete();
         }
 
         private void OnFadeOutComplete()
         {
-            SetVolume(0);
             VolumeStatus = VolumeStatuses.Static;
+            Player.SetVolume(0);
 
             if (StopAfterFade)
             {
@@ -329,15 +330,10 @@ namespace EnsoMusicPlayer
             LoopSource.volume = volume;
         }
 
-        internal void SetPlayerVolume(float playerVolume)
-        {
-            PlayerVolume = playerVolume;
-        }
-
         private void InitializeVolume()
         {
             VolumeStatus = VolumeStatuses.Static;
-            SetVolume(PlayerVolume);
+            SetVolume(Player.Volume);
         }
 
         private void RemovePauseState()

--- a/Tests/Enso_MusicPlayerEventTests.cs
+++ b/Tests/Enso_MusicPlayerEventTests.cs
@@ -206,8 +206,6 @@ public class Enso_MusicPlayerEventTests {
         GameObject player = new GameObject();
         player.AddComponent<AudioListener>();
         module = player.AddComponent<Speaker>();
-
-        module.SetPlayerVolume(1f);
     }
 
     private void SetUpMusicPlayer()

--- a/Tests/Enso_MusicPlayerTests.cs
+++ b/Tests/Enso_MusicPlayerTests.cs
@@ -133,8 +133,6 @@ namespace EnsoMusicPlayer
 
             yield return null;
 
-            float volume = musicPlayer.Volume;
-
             musicPlayer.SetVolume(.5f);
 
             yield return null;
@@ -144,23 +142,46 @@ namespace EnsoMusicPlayer
         }
 
         [UnityTest]
+        public IEnumerator Enso_FadeTo()
+        {
+            SetUpMusicPlayer();
+            musicPlayer.CrossFadeTime = .5f;
+
+            yield return null;
+
+            musicPlayer.FadeTo(.5f);
+
+            yield return new WaitForSeconds(musicPlayer.CrossFadeTime);
+
+            Assert.AreEqual(.5f, module.Volume);
+
+            musicPlayer.FadeTo(.75f);
+
+            yield return new WaitForSeconds(musicPlayer.CrossFadeTime);
+
+            Assert.AreEqual(.75f, module.Volume);
+        }
+
+        [UnityTest]
         public IEnumerator Enso_FadeInTrack()
         {
             SetUpMusicPlayer();
 
             yield return null;
 
-            musicPlayer.SetVolume(0);
+            musicPlayer.CrossFadeTime = 1f;
+            musicPlayer.SetVolume(.75f);
             MusicTrack track = new MusicTrack
             {
                 Track = AudioClip.Create("test", 2000, 1, 1000, false)
             };
             track.CreateAndCacheClips();
             module.Play(track, EnsoConstants.PlayEndlessly);
+            module.SetSpeakerVolume(0f);
 
             yield return null;
 
-            module.FadeIn(2);
+            module.FadeIn(musicPlayer.CrossFadeTime);
             float originalVolume = speaker1.volume;
 
             Assert.AreEqual(Speaker.VolumeStatuses.FadingIn, module.VolumeStatus);
@@ -172,7 +193,7 @@ namespace EnsoMusicPlayer
             yield return new WaitForSeconds(2);
 
             Assert.AreEqual(Speaker.VolumeStatuses.Static, module.VolumeStatus);
-            Assert.AreEqual(speaker1.volume, musicPlayer.Volume, "Speaker volume doesn't equal PlayerVolume when fading in is complete.");
+            Assert.AreEqual(musicPlayer.Volume, speaker1.volume, "Speaker volume doesn't equal 1 when fading in is complete.");
         }
 
         [UnityTest]
@@ -325,6 +346,86 @@ namespace EnsoMusicPlayer
             // Assert
             Assert.IsTrue(musicPlayer.CurrentTime >= fadeInPoint);
             Assert.AreEqual(Speaker.VolumeStatuses.FadingIn, module.VolumeStatus);
+        }
+
+        [UnityTest]
+        public IEnumerator Enso_VolumeShouldBeSetProperlyBeforeDuringAndAfterCrossfade()
+        {
+            // Arrange
+            SetUpMusicPlayer();
+            musicPlayer.CrossFadeTime = .5f;
+            musicPlayer.SetVolume(.25f);
+
+            // Act
+            musicPlayer.Play("MusicTest");
+
+            float originalVolume = module.LoopSource.volume;
+
+            yield return null;
+
+            musicPlayer.CrossFadeTo("MusicTest");
+
+            Assert.AreEqual(originalVolume, module.Volume, "Volume is not the same for speaker 1 before crossfade");
+            Assert.AreEqual(0f, module2.Volume, "Speaker 2 is not muted before crossfade");
+
+            yield return new WaitForSeconds(musicPlayer.CrossFadeTime / 2f);
+
+            Assert.AreNotEqual(0f, module2.Volume, "Speaker 2 isn't fading in during crossfade");
+
+            yield return new WaitForSeconds(musicPlayer.CrossFadeTime / 2f);
+
+            // Assert
+            Assert.AreEqual(originalVolume, module2.LoopSource.volume, "Speaker 2 is not at the original volume after crossfade");
+        }
+
+        [UnityTest]
+        public IEnumerator Enso_VolumeShouldBeSetProperlyAfterDoubleCrossfade()
+        {
+            // Arrange
+            SetUpMusicPlayer();
+            musicPlayer.CrossFadeTime = .5f;
+            musicPlayer.SetVolume(.25f);
+
+            // Act
+            musicPlayer.Play("MusicTest");
+
+            float originalVolume = module.LoopSource.volume;
+
+            yield return null;
+
+            musicPlayer.CrossFadeTo("MusicTest");
+
+            yield return new WaitForSeconds(musicPlayer.CrossFadeTime);
+
+            musicPlayer.CrossFadeTo("MusicTest");
+
+            yield return new WaitForSeconds(musicPlayer.CrossFadeTime);
+
+            // Assert
+            Assert.AreNotEqual(0f, module.Volume, "Speaker 1 is not at the original volume after a double crossfade");
+        }
+
+        [UnityTest]
+        public IEnumerator Enso_VolumeShouldNotBeDifferentAfterCrossfadeAtPoint()
+        {
+            // Arrange
+            SetUpMusicPlayer();
+            musicPlayer.CrossFadeTime = .5f;
+            musicPlayer.SetVolume(.25f);
+
+            // Act
+            musicPlayer.Play("MusicTest");
+
+            float originalVolume = module.LoopSource.volume;
+
+            yield return null;
+
+            musicPlayer.CrossFadeAtPoint("MusicTest", .1f);
+
+            yield return new WaitForSeconds(musicPlayer.CrossFadeTime);
+
+            // Assert
+            Assert.AreEqual(originalVolume, module2.LoopSource.volume);
         }
 
         [UnityTest]
@@ -564,7 +665,7 @@ namespace EnsoMusicPlayer
 
             // Act
             musicPlayer.Play("MusicTest");
-            musicPlayer.SetVolume(0);
+            musicPlayer.SetVolume(.75f);
 
             yield return null;
 
@@ -577,7 +678,7 @@ namespace EnsoMusicPlayer
             yield return null;
 
             // Assert
-            Assert.IsTrue(speaker1.volume >= 1f, "Speaker volume is at " + speaker1.volume);
+            Assert.IsTrue(speaker1.volume >= .75f, "Speaker volume is at " + speaker1.volume);
         }
 
         [UnityTest]

--- a/Tests/Enso_MusicPlayerTests.cs
+++ b/Tests/Enso_MusicPlayerTests.cs
@@ -127,12 +127,30 @@ namespace EnsoMusicPlayer
         }
 
         [UnityTest]
+        public IEnumerator Enso_SetVolume()
+        {
+            SetUpMusicPlayer();
+
+            yield return null;
+
+            float volume = musicPlayer.Volume;
+
+            musicPlayer.SetVolume(.5f);
+
+            yield return null;
+
+            Assert.AreEqual(speaker1.volume, musicPlayer.Volume);
+            Assert.AreEqual(speaker2.volume, musicPlayer.Volume);
+        }
+
+        [UnityTest]
         public IEnumerator Enso_FadeInTrack()
         {
             SetUpMusicPlayer();
 
             yield return null;
 
+            musicPlayer.SetVolume(0);
             MusicTrack track = new MusicTrack
             {
                 Track = AudioClip.Create("test", 2000, 1, 1000, false)
@@ -151,10 +169,10 @@ namespace EnsoMusicPlayer
 
             Assert.AreNotEqual(speaker1.volume, originalVolume, "The volume isn't changing when fading in.");
 
-            yield return new WaitForSecondsRealtime(2);
+            yield return new WaitForSeconds(2);
 
             Assert.AreEqual(Speaker.VolumeStatuses.Static, module.VolumeStatus);
-            Assert.AreEqual(speaker1.volume, originalVolume, "Speaker volume doesn't equal PlayerVolume when fading in is complete.");
+            Assert.AreEqual(speaker1.volume, musicPlayer.Volume, "Speaker volume doesn't equal PlayerVolume when fading in is complete.");
         }
 
         [UnityTest]
@@ -531,6 +549,53 @@ namespace EnsoMusicPlayer
             yield return new WaitForSeconds(2);
 
             musicPlayer.CrossFadeAtPoint("MusicTest", 0f);
+
+            yield return null;
+
+            // Assert
+            Assert.IsTrue(speaker1.volume <= 0f, "Speaker volume is at " + speaker1.volume);
+        }
+
+        [UnityTest]
+        public IEnumerator Enso_FadeInAfterFadeInShouldDoNothing()
+        {
+            // Arrange
+            SetUpMusicPlayer();
+
+            // Act
+            musicPlayer.Play("MusicTest");
+            musicPlayer.SetVolume(0);
+
+            yield return null;
+
+            musicPlayer.FadeIn();
+
+            yield return new WaitForSeconds(2);
+
+            musicPlayer.FadeIn();
+
+            yield return null;
+
+            // Assert
+            Assert.IsTrue(speaker1.volume >= 1f, "Speaker volume is at " + speaker1.volume);
+        }
+
+        [UnityTest]
+        public IEnumerator Enso_FadeOutAfterFadeOutShouldDoNothing()
+        {
+            // Arrange
+            SetUpMusicPlayer();
+
+            // Act
+            musicPlayer.Play("MusicTest");
+
+            yield return null;
+
+            musicPlayer.FadeOut();
+
+            yield return new WaitForSeconds(2);
+
+            musicPlayer.FadeOut();
 
             yield return null;
 


### PR DESCRIPTION
This merge introduces bugfixes and API changes for the 1.4 release. These API changes involve clarifying that any publically-facing fade functions will not mutate the player's actual volume. Fades only affect the audio sources in the player.